### PR TITLE
Fix #19 - Remove links in docker-compose

### DIFF
--- a/python/ex-01/docker-compose.yml
+++ b/python/ex-01/docker-compose.yml
@@ -2,14 +2,14 @@ version: "3.3"
 services:
   proxy:
     image: nginx
-    links:
+    depends_on:
     - api
     networks: [ fe ]
   api:
     image: python:3.8-alpine
     environment:
       MYSQL_ROOT_PASSWORD: secret
-    links:
+    depends_on:
     - db
     volumes:
     - filestore:/var/lib/store


### PR DESCRIPTION
Fixes #19.

## This PR 

replace `links` with `depends_on` in the file `docker-compose.yml`, since the former [is deprecated](https://docs.docker.com/compose/compose-file/#links)

## See

https://docs.docker.com/compose/startup-order/